### PR TITLE
test: add basic XCTest coverage for core features

### DIFF
--- a/MyChatTests/ChatCreationDeletionTests.swift
+++ b/MyChatTests/ChatCreationDeletionTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import SwiftData
+@testable import MyChat
+
+final class ChatCreationDeletionTests: XCTestCase {
+    func testChatLifecycle() throws {
+        let container = try ModelContainer(for: Chat.self, Message.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let context = ModelContext(container)
+        let chat = Chat(title: "Test Chat")
+        context.insert(chat)
+        try context.save()
+        let fetch = FetchDescriptor<Chat>()
+        var chats = try context.fetch(fetch)
+        XCTAssertEqual(chats.count, 1)
+        context.delete(chat)
+        try context.save()
+        chats = try context.fetch(fetch)
+        XCTAssertTrue(chats.isEmpty)
+    }
+}

--- a/MyChatTests/ImageAttachmentTests.swift
+++ b/MyChatTests/ImageAttachmentTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import MyChat
+
+private final class MockImageProvider: ImageProvider {
+    let id = "mock"
+    let displayName = "Mock Provider"
+    func listModels() async throws -> [String] { ["mock-model"] }
+    func generateImage(prompt: String, model: String) async throws -> Data { Data([0x00, 0x01]) }
+}
+
+final class ImageAttachmentTests: XCTestCase {
+    func testGenerateImageReturnsData() async throws {
+        let provider = MockImageProvider()
+        let data = try await provider.generateImage(prompt: "hi", model: "mock-model")
+        XCTAssertFalse(data.isEmpty)
+    }
+}

--- a/MyChatTests/MathRenderingTests.swift
+++ b/MyChatTests/MathRenderingTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import MyChat
+
+final class MathRenderingTests: XCTestCase {
+    func testMathWebViewStoresLatex() {
+        let view = MathWebView(latex: "x^2")
+        XCTAssertEqual(view.latex, "x^2")
+    }
+}

--- a/MyChatTests/MessageSendingTests.swift
+++ b/MyChatTests/MessageSendingTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import MyChat
+
+final class MessageSendingTests: XCTestCase {
+    func testSendMessageAddsToChat() {
+        let chat = Chat(title: "Test")
+        let message = Message(role: "user", content: "Hello", chat: chat)
+        chat.messages.append(message)
+        XCTAssertEqual(chat.messages.count, 1)
+        XCTAssertEqual(chat.messages.first?.content, "Hello")
+    }
+}

--- a/MyChatTests/ModelSelectionTests.swift
+++ b/MyChatTests/ModelSelectionTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import SwiftData
+@testable import MyChat
+
+final class ModelSelectionTests: XCTestCase {
+    func testModelSelectionUpdatesEnabledModels() throws {
+        let container = try ModelContainer(for: AppSettings.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let context = ModelContext(container)
+        let store = SettingsStore(context: context)
+        store.openAIEnabled.insert("gpt-test")
+        store.save()
+        let fetch = FetchDescriptor<AppSettings>()
+        let settings = try context.fetch(fetch).first
+        XCTAssertTrue(settings?.openAIEnabledModels.contains("gpt-test") ?? false)
+    }
+}

--- a/MyChatTests/SettingsFlowTests.swift
+++ b/MyChatTests/SettingsFlowTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import SwiftData
+@testable import MyChat
+
+final class SettingsFlowTests: XCTestCase {
+    func testSettingsSavePersistsChanges() throws {
+        let container = try ModelContainer(for: AppSettings.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let context = ModelContext(container)
+        let store = SettingsStore(context: context)
+        store.defaultModel = "new-model"
+        store.interfaceTheme = "dark"
+        store.save()
+        let fetch = FetchDescriptor<AppSettings>()
+        let settings = try context.fetch(fetch).first
+        XCTAssertEqual(settings?.defaultModel, "new-model")
+        XCTAssertEqual(settings?.interfaceTheme, "dark")
+    }
+}

--- a/MyChatTests/ThemeSwitchingTests.swift
+++ b/MyChatTests/ThemeSwitchingTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import SwiftData
+@testable import MyChat
+
+final class ThemeSwitchingTests: XCTestCase {
+    func testThemeSwitchingUpdatesSettings() throws {
+        let container = try ModelContainer(for: AppSettings.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let context = ModelContext(container)
+        let store = SettingsStore(context: context)
+        store.interfaceTheme = "dark"
+        store.save()
+        let fetch = FetchDescriptor<AppSettings>()
+        let settings = try context.fetch(fetch).first
+        XCTAssertEqual(settings?.interfaceTheme, "dark")
+    }
+}


### PR DESCRIPTION
## Summary
- add initial MyChatTests target files for chat lifecycle, messaging, settings, themes, model selection, image attachments, and math rendering

## Testing
- `xcodebuild test -project MyChat.xcodeproj -scheme MyChat -destination 'platform=iOS Simulator,name=iPhone 16'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d9858c4c832eaaa65dd1a090b104