### PR TITLE
feat: add code themes and iosMath color support

### DIFF
--- a/MyChat/AIResponseView.swift
+++ b/MyChat/AIResponseView.swift
@@ -197,6 +197,7 @@ private struct MathBlockSegment: View {
 private struct HighlightedCodeView: UIViewRepresentable {
     let code: String
     let language: String?
+    @Environment(\.colorScheme) private var colorScheme
     func makeUIView(context: Context) -> UITextView {
         let tv = UITextView()
         tv.isEditable = false
@@ -206,7 +207,8 @@ private struct HighlightedCodeView: UIViewRepresentable {
         return tv
     }
     func updateUIView(_ uiView: UITextView, context: Context) {
-        if let highlightr = Highlightr(), let theme = highlightr.setTheme(to: "xcode") {
+        if let highlightr = Highlightr(),
+           let theme = highlightr.setTheme(to: CodeTheme.current(for: colorScheme)) {
             highlightr.theme = theme
             let highlighted = highlightr.highlight(code, as: language)
             uiView.attributedText = highlighted
@@ -275,10 +277,12 @@ private struct IOSMathLabel: UIViewRepresentable {
         v.labelMode = .text
         v.textAlignment = .center
         v.latex = latex
+        v.textColor = .label
         return v
     }
     func updateUIView(_ uiView: MTMathUILabel, context: Context) {
         uiView.latex = latex
+        uiView.textColor = .label
     }
 }
 #endif

--- a/MyChat/ChatStyles.swift
+++ b/MyChat/ChatStyles.swift
@@ -5,5 +5,17 @@ enum ChatStyle {
     static let bubbleCorner: CGFloat = 16
 }
 
+/// Highlight.js theme names used for syntax highlighting
+enum CodeTheme {
+    /// Theme optimized for light interface style
+    static let light = "xcode"
+    /// Theme optimized for dark interface style
+    static let dark = "atom-one-dark"
+
+    static func current(for colorScheme: ColorScheme) -> String {
+        colorScheme == .dark ? dark : light
+    }
+}
+
 // MarkdownUI theme removed. Down-based renderer returns AttributedString.
 


### PR DESCRIPTION
## Summary
- add light/dark highlight.js theme names
- switch code block highlighting based on color scheme
- ensure iosMath labels use dynamic text color

## Testing
- `xcodebuild -project MyChat.xcodeproj -scheme MyChat build` *(fails: command not found)*
- `xcodebuild test -project MyChat.xcodeproj -scheme MyChat -destination 'platform=iOS Simulator,name=iPhone 16'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d99cec54832eac46159fa9621433