### PR TITLE
docs: document unfinished areas

### DIFF
--- a/MyChat/AIResponseView.swift
+++ b/MyChat/AIResponseView.swift
@@ -315,7 +315,7 @@ private struct InlineMathParagraph: View {
                     #if canImport(iosMath)
                     IOSMathLabel(latex: ltx)
                     #elseif canImport(SwiftMath)
-                    // Inline placeholder when SwiftMath is present but no direct view is integrated.
+                    // TODO: Integrate a SwiftMath view for inline formulas instead of this placeholder.
                     Text(ltx)
                         .font(.system(.body, design: .monospaced))
                     #else

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -20,3 +20,5 @@
 - Run on simulator, verify Settings changes persist via `SettingsStore.save()`.
 - Audit other views for `SettingsStore` usage (none found via ripgrep).
 - Add `docs/TODO.md` maintenance to ongoing workflow.
+- Remove temporary `Combine` imports once Observation migration completes.
+- Integrate SwiftMath inline view to replace placeholder in `AIResponseView`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11,4 +11,6 @@ Updated: 2025-09-09
 - [ ] Create `MyChat.xctestplan`
 - [ ] Code theme polish (choose light/dark code themes)
 - [ ] Verify math with iosMath installed (block + inline)
+- [ ] Remove temporary `Combine` imports once Observation migration completes
+- [ ] Integrate SwiftMath inline view to replace placeholder in `AIResponseView`
 


### PR DESCRIPTION
## Summary
- annotate SwiftMath inline math placeholder in `AIResponseView`
- record follow-ups for temporary Combine imports and SwiftMath integration in docs

## Testing
- `xcodebuild -project MyChat.xcodeproj -scheme MyChat -destination 'generic/platform=iOS Simulator' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a249a4a8832e8350c7a70c8abcb1