### PR TITLE
feat: finalize SwiftMath rendering and remove iosMath

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ To keep the human in the loop at all times, follow these rules in every session:
 - SPM Dependencies (present):
   - **Down** (branch master): Markdown parsing and rendering (replaced MarkdownUI)
   - **HighlighterSwift** (product: Highlighter) 1.1.7: Code syntax highlighting (optional)
-  - **SwiftMath** 1.7.3 and/or **iosMath**: Mathematical formula rendering (optional)
+  - **SwiftMath** 1.7.3: Mathematical formula rendering (optional)
   - **PhosphorSwift** 2.1.0: Icon set
 - Quick build check: `xcodebuild -project MyChat.xcodeproj -scheme MyChat -destination 'generic/platform=iOS Simulator' build`
 
@@ -267,7 +267,7 @@ To keep the human in the loop at all times, follow these rules in every session:
   - Providers screen verifies API keys and lists models via `ProviderAPIs`.
 
 - Rendering
-  - Markdown (Down → AttributedString with tinted links and inline-code styling), code highlighting (Highlightr/Highlighter when available, monospaced fallback), math via iosMath or SwiftMath branch with KaTeX fallback.
+  - Markdown (Down → AttributedString with tinted links and inline-code styling), code highlighting (Highlightr/Highlighter when available, monospaced fallback), math via SwiftMath with KaTeX fallback.
 
 ## Migration Notes (from ChatApp to MyChat)
 
@@ -289,7 +289,7 @@ To keep the human in the loop at all times, follow these rules in every session:
 - [x] Update AIResponseView.swift to use Down instead of MarkdownUI
 - [x] Update ChatStyles.swift (MarkdownUI theme removed)
 - [x] Add Highlighter adapter path (Highlightr/Highlighter)
-- [x] Fix math renderer tiers (iosMath → label, SwiftMath → KaTeX fallback, else KaTeX)
+- [x] Fix math renderer tiers (SwiftMath → label with KaTeX fallback)
 - [x] Build project successfully on simulator
 - [ ] Test basic chat functionality with API keys
 - [ ] Add UI polish for code themes (optional)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ This is a SwiftUI-based iOS chat application with AI provider integration, built
 #### context7 (Library Documentation)
 - **When**: Working with third-party dependencies
 - **Key Tools**: `resolve-library-id`, `get-library-docs`
-- **Current Dependencies**: Down (markdown), Highlightr (optional), SwiftMath/iosMath (optional)
+- **Current Dependencies**: Down (markdown), Highlightr (optional), SwiftMath (optional)
 
 #### desktop-commander (File Operations)
 - **When**: File reads/writes/edits, process control
@@ -136,7 +136,7 @@ Always verify with **sosumi.searchAppleDocumentation** before implementing:
 Use **context7** to pull current documentation:
 - Down for markdown rendering
 - Highlightr for code syntax highlighting (if added)
-- SwiftMath/iosMath for LaTeX rendering (if added)
+- SwiftMath for LaTeX rendering (if added)
 - Any new SPM dependencies
 
 ### Version Freshness
@@ -260,7 +260,7 @@ Use **context7** to pull current documentation:
 ### Swift Package Manager
 - **Down**: Markdown rendering (replacing MarkdownUI from old project)
 - **Highlightr**: Syntax highlighting for code blocks (optional)
-- **SwiftMath/iosMath**: Mathematical formula rendering (optional)
+- **SwiftMath**: Mathematical formula rendering (optional)
 
 ### System Frameworks
 - SwiftUI, SwiftData, Foundation, PhotosUI for core functionality

--- a/MyChat/AIResponseView.swift
+++ b/MyChat/AIResponseView.swift
@@ -8,10 +8,7 @@ import Highlightr
 #endif
 
 #if canImport(SwiftMath)
-import SwiftMath // used only for conditional compilation; no direct UI references
-#endif
-#if canImport(iosMath)
-import iosMath
+import SwiftMath
 #endif
 
 struct AIResponseView: View {
@@ -185,14 +182,9 @@ private struct MathBlockSegment: View {
     let latex: String
     var body: some View {
         Group {
-            #if canImport(iosMath)
-            IOSMathLabel(latex: latex)
+            #if canImport(SwiftMath)
+            MathUILabelView(latex: latex)
                 .padding(.vertical, 4)
-            #elseif canImport(SwiftMath)
-            // SwiftMath present: if it exposes a SwiftUI view in future, plug it here.
-            // For now, prefer KaTeX WebView for accurate display-mode rendering.
-            MathWebView(latex: latex, displayMode: true)
-                .frame(minHeight: 28)
             #else
             // Web-based KaTeX fallback (auto-sizes; allows horizontal scroll)
             MathWebView(latex: latex, displayMode: true)
@@ -278,8 +270,8 @@ private struct HighlightedCodeView: UIViewRepresentable {
 }
 #endif
 
-#if canImport(iosMath)
-private struct IOSMathLabel: UIViewRepresentable {
+#if canImport(SwiftMath)
+private struct MathUILabelView: UIViewRepresentable {
     let latex: String
     func makeUIView(context: Context) -> MTMathUILabel {
         let v = MTMathUILabel()
@@ -312,12 +304,8 @@ private struct InlineMathParagraph: View {
                 case .text(let t):
                     Text(t)
                 case .math(let ltx):
-                    #if canImport(iosMath)
-                    IOSMathLabel(latex: ltx)
-                    #elseif canImport(SwiftMath)
-                    // Inline placeholder when SwiftMath is present but no direct view is integrated.
-                    Text(ltx)
-                        .font(.system(.body, design: .monospaced))
+                    #if canImport(SwiftMath)
+                    MathUILabelView(latex: ltx)
                     #else
                     MathWebView(latex: ltx, displayMode: false)
                         .frame(minHeight: 22)

--- a/MyChat/ChatCanvasView.swift
+++ b/MyChat/ChatCanvasView.swift
@@ -1,10 +1,8 @@
 import SwiftUI
 import WebKit
-import Combine
-
 // Controller object used to send commands into the WebCanvas once ready.
 @MainActor
-final class ChatCanvasController: ObservableObject {
+final class ChatCanvasController {
     fileprivate weak var webView: WKWebView?
     fileprivate var isReady: Bool = false
     fileprivate var pending: [() -> Void] = []
@@ -64,7 +62,7 @@ struct CanvasMessage: Codable {
 enum CanvasTheme: String, Codable { case light, dark }
 
 struct ChatCanvasView: UIViewRepresentable {
-    @ObservedObject var controller: ChatCanvasController
+    var controller: ChatCanvasController
     var theme: CanvasTheme
 
     func makeCoordinator() -> Coordinator { Coordinator(controller: controller) }

--- a/MyChat/ChatView.swift
+++ b/MyChat/ChatView.swift
@@ -120,7 +120,7 @@ struct ChatView: View {
         let messages: [Message]
         let streamingText: String?
         let isSending: Bool
-        @StateObject private var controller = ChatCanvasController()
+        @State private var controller = ChatCanvasController()
         @Environment(\.colorScheme) private var colorScheme
         @State private var didStartStream = false
         var body: some View {

--- a/MyChat/NetworkClient.swift
+++ b/MyChat/NetworkClient.swift
@@ -1,6 +1,5 @@
 // Networking/NetworkClient.swift
 import Foundation
-import Combine // TODO: Temporary import to unblock build; remove after Observation-based Settings migration finalizes if unused.
 
 struct NetworkClient {
     let session: URLSession

--- a/MyChat/OpenAIImageProvider.swift
+++ b/MyChat/OpenAIImageProvider.swift
@@ -1,6 +1,5 @@
 // Providers/OpenAIImageProvider.swift
 import Foundation
-import Combine // TODO: Temporary import to unblock build; remove after Observation migration if no longer needed.
 
 struct OpenAIImageProvider: ImageProvider {
     let id = "openai-images"

--- a/MyChat/SystemPrompt.swift
+++ b/MyChat/SystemPrompt.swift
@@ -10,7 +10,7 @@ Rules:
 - For math:
   - Block math: wrap LaTeX in $$ ... $$.
   - Inline math: wrap LaTeX in $ ... $.
-  - Use standard LaTeX syntax compatible with iosMath (no HTML/MathML).
+  - Use standard LaTeX syntax compatible with SwiftMath/KaTeX (no HTML/MathML).
 - When including both code and prose, separate sections clearly.
 - Do not include screenshots or images in output; describe them in text.
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -7,6 +7,7 @@
 - `SettingsView` and its subviews refactored to use `@Environment(SettingsStore.self)` with `@Bindable` in bodies where needed.
 - Previews updated: `SettingsView` uses an in-memory `ModelContainer` and injects a preview `SettingsStore`.
 - Fixed UIPlayground preview build issues by scoping mock types and adding `import Combine` where `ObservableObject/@Published` are used (playground-only).
+- SwiftMath handles inline and block math with KaTeX fallback; iosMath code removed and temporary `Combine` imports cleaned.
 - Build validated for iOS Simulator. Resolved a locked build DB by removing `DerivedData/.../XCBuildData` and retrying.
 
 ## Artifacts

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,11 +4,13 @@ Updated: 2025-09-09
 
 - [x] Replace MarkdownUI with Down and wire renderer
 - [x] Add code highlighting adapter (Highlightr/Highlighter) with fallback
-- [x] Fix math renderer tiers (iosMath preferred; SwiftMath branch compiles; KaTeX fallback)
+- [x] Fix math renderer tiers (SwiftMath with KaTeX fallback)
 - [x] Guard WebCanvas asset loading; no crash when absent
 - [ ] Add unit test target `MyChatTests` (NetworkClient + parser tests)
 - [ ] Add UI test target `MyChatUITests`
 - [ ] Create `MyChat.xctestplan`
 - [ ] Code theme polish (choose light/dark code themes)
-- [ ] Verify math with iosMath installed (block + inline)
+- [ ] Verify math rendering with SwiftMath and KaTeX fallback (block + inline)
+- [x] Remove temporary `Combine` imports once Observation migration completes
+- [x] Integrate SwiftMath inline view to replace placeholder in `AIResponseView`
 

--- a/porting.md
+++ b/porting.md
@@ -29,7 +29,7 @@ Successfully transferred Swift code from ChatApp_FreshSource_2025-09-06 backup t
 The following Swift packages need to be added to the project:
 - `Down` - For markdown rendering (replacing MarkdownUI)
 - `Highlightr` or `HighlighterSwift` - For code syntax highlighting (optional but recommended)
-- `SwiftMath` or `iosMath` - For LaTeX math rendering (optional)
+- `SwiftMath` - For LaTeX math rendering (optional)
 
 ### 4. System Prompt Configuration
 **Priority: MEDIUM**
@@ -65,7 +65,7 @@ The following Swift packages need to be added to the project:
 - Conditional imports audited and updated:
   - Removed MarkdownUI gates; added Down-based path.
   - Code highlighting supports `Highlightr` or `Highlighter` (smittytone/HighlighterSwift) with safe fallback.
-  - Math rendering split: `iosMath` path uses `MTMathUILabel`; `SwiftMath` branch compiles without referencing `MTMathUILabel` and falls back to KaTeX.
+  - Math rendering uses `SwiftMath`'s `MTMathUILabel`; when SwiftMath is unavailable, the app falls back to KaTeX via `MathWebView`.
 
 ### 2. Preview Providers
 - Preview providers reference in-memory model containers
@@ -88,13 +88,13 @@ The following Swift packages need to be added to the project:
 - [ ] Test image attachments
 - [x] Test markdown rendering (basic)
 - [x] Code highlighting path present (HighlighterSwift); theme polish TBD
-- [ ] Test math rendering (iosMath when added; SwiftMath fallback verified compiles)
+- [ ] Test math rendering (SwiftMath block + inline, KaTeX fallback)
 
 ## Status Updates (2025-09-09)
 
 - Down integration complete; MarkdownUI removed.
 - Highlighter/Highlightr adapter added with graceful fallback.
-- Math renderer fixed: iosMath preferred; SwiftMath branch compiles and falls back to KaTeX.
+- Math renderer fixed: SwiftMath integrated with KaTeX fallback.
 - WebCanvas loader guarded: loads local `WebCanvas/dist/index.html` or `ChatApp/WebCanvas/dist/index.html`; otherwise no-op with comment.
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- standardize on SwiftMath for inline and block math with KaTeX fallback
- drop remaining Combine usage in ChatCanvas and revise system prompt
- update docs to reflect SwiftMath-only math strategy

## Testing
- `xcodebuild -project MyChat.xcodeproj -scheme MyChat -destination 'generic/platform=iOS Simulator' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a249a4a8832e8350c7a70c8abcb1