### PR TITLE
feat: expand LLM provider message handling

### DIFF
--- a/MyChat/Providers/Anthropic/AnthropicProvider.swift
+++ b/MyChat/Providers/Anthropic/AnthropicProvider.swift
@@ -64,12 +64,14 @@ struct AnthropicProvider: AIProviderAdvanced {
         let caps = ModelCapabilitiesStore.get(provider: id, model: model)
         let cacheFlag = (caps?.enablePromptCaching ?? false)
         func toBlocks(_ parts: [AIMessage.Part]) -> [ContentBlock] {
-            parts.map { p in
+            parts.compactMap { p in
                 switch p {
                 case .text(let t):
                     return ContentBlock(type: "text", text: t, source: nil, cache_control: cacheFlag ? .init(type: "ephemeral") : nil)
                 case .imageData(let data, let mime):
                     return ContentBlock(type: "input_image", text: nil, source: .init(media_type: mime, data: data.base64EncodedString()), cache_control: nil)
+                default:
+                    return nil
                 }
             }
         }
@@ -81,6 +83,8 @@ struct AnthropicProvider: AIProviderAdvanced {
                 return MessageItem(role: "user", content: toBlocks(m.parts))
             case .assistant:
                 return MessageItem(role: "assistant", content: toBlocks(m.parts))
+            case .tool:
+                return nil
             }
         }
 

--- a/MyChat/Providers/Core/AIProvider.swift
+++ b/MyChat/Providers/Core/AIProvider.swift
@@ -2,10 +2,13 @@
 import Foundation
 
 struct AIMessage {
-    enum Role: String, Codable { case system, user, assistant }
+    enum Role: String, Codable { case system, user, assistant, tool }
     enum Part: Codable, Hashable {
         case text(String)
         case imageData(Data, mime: String)
+        case toolCall(id: String?, name: String, arguments: String)
+        case toolResult(id: String?, content: String)
+        case fileReference(id: String)
     }
     var role: Role
     var parts: [Part]


### PR DESCRIPTION
## Summary
- extend `GoogleProvider` with function call, tool result, and file reference support to preserve full conversation state
- add multipart message and tool call handling to `XAIProvider` for Grok chat completions
- encode Gemini function call arguments and tool responses as structured JSON objects

## Testing
- `xcodebuild -project MyChat.xcodeproj -scheme MyChat -destination 'generic/platform=iOS Simulator' build` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a5b067a0832e889d4ef33dbb8e22