### PR TITLE
fix: anchor dock bar to bottom

### DIFF
--- a/MyChat/RootView.swift
+++ b/MyChat/RootView.swift
@@ -10,23 +10,20 @@ struct RootView: View {
     @Namespace private var highlightNS
 
     var body: some View {
-        ZStack(alignment: .bottom) {
-            Group {
-                switch tab {
-                case .home: ContentView()
-                case .chat: ChatRootView()
-                case .notes: NotesPlaceholderView()
-                case .media: MediaPlaceholderView()
-                case .settings: SettingsView()
-                }
+        Group {
+            switch tab {
+            case .home: ContentView()
+            case .chat: ChatRootView()
+            case .notes: NotesPlaceholderView()
+            case .media: MediaPlaceholderView()
+            case .settings: SettingsView()
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-            // Custom dock bar
-            DockTabBar(selected: $tab, highlightNS: highlightNS)
-                .padding(.bottom, 2)
-                .background(Color.clear.ignoresSafeArea(edges: .bottom))
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            DockTabBar(selected: $tab, highlightNS: highlightNS)
+        }
+        .background(T.bg.ignoresSafeArea())
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent dock bar from floating by anchoring it using `safeAreaInset`
- extend app background under dock bar to avoid any content showing beneath it

## Testing
- `xcodebuild -project MyChat.xcodeproj -scheme MyChat build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c36c0c3b58832ebcde1eb3e3720730