### PR TITLE
feat: reinforce icon and accent text styling

### DIFF
--- a/MyChat/Icons.swift
+++ b/MyChat/Icons.swift
@@ -7,9 +7,9 @@ enum AppIcon {
     // Always use bold weight by default
     @ViewBuilder static func gear(_ size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.gear.bold.frame(width: size, height: size)
+        Ph.gear.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "gear").font(.system(size: size, weight: .bold))
+        Image(systemName: "gearshape.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func grabber(_ size: CGFloat = 16) -> some View {
@@ -22,121 +22,121 @@ enum AppIcon {
     }
     @ViewBuilder static func home(_ size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.house.bold.frame(width: size, height: size)
+        Ph.house.fill.frame(width: size, height: size)
         #else
         Image(systemName: "house.fill").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func chat(_ size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.chatCircleDots.bold.frame(width: size, height: size)
+        Ph.chatCircleDots.fill.frame(width: size, height: size)
         #else
         Image(systemName: "message.fill").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func note(_ size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.note.bold.frame(width: size, height: size)
+        Ph.note.fill.frame(width: size, height: size)
         #else
         Image(systemName: "note.text").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func share(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.shareNetwork.bold.frame(width: size, height: size)
+        Ph.shareNetwork.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "square.and.arrow.up").font(.system(size: size, weight: .bold))
+        Image(systemName: "square.and.arrow.up.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func trash(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.trash.bold.frame(width: size, height: size)
+        Ph.trash.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "trash").font(.system(size: size, weight: .bold))
+        Image(systemName: "trash.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func compose(_ size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.pencilSimple.bold.frame(width: size, height: size)
+        Ph.pencilSimple.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "square.and.pencil").font(.system(size: size, weight: .bold))
+        Image(systemName: "square.and.pencil").font(.system(size: size, weight: .heavy))
         #endif
     }
     // Content-type glyphs used in chat history cards
     @ViewBuilder static func image(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.image.bold.frame(width: size, height: size)
+        Ph.image.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "photo").font(.system(size: size, weight: .bold))
+        Image(systemName: "photo.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func text(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.textT.bold.frame(width: size, height: size)
+        Ph.textT.fill.frame(width: size, height: size)
         #else
         Image(systemName: "textformat").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func code(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.code.bold.frame(width: size, height: size)
+        Ph.code.fill.frame(width: size, height: size)
         #else
         Image(systemName: "curlybraces").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func audio(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.waveform.bold.frame(width: size, height: size)
+        Ph.waveform.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "waveform").font(.system(size: size, weight: .bold))
+        Image(systemName: "waveform").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func file(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.file.bold.frame(width: size, height: size)
+        Ph.file.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "doc").font(.system(size: size, weight: .bold))
+        Image(systemName: "doc.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func doc(_ size: CGFloat = 16) -> some View { file(size) }
     @ViewBuilder static func agent(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.robot.bold.frame(width: size, height: size)
+        Ph.robot.fill.frame(width: size, height: size)
         #else
         Image(systemName: "brain.head.profile").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func project(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.squaresFour.bold.frame(width: size, height: size)
+        Ph.squaresFour.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "square.grid.2x2").font(.system(size: size, weight: .bold))
+        Image(systemName: "square.grid.2x2.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func user(_ size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.userCircle.bold.frame(width: size, height: size)
+        Ph.userCircle.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "person.circle").font(.system(size: size, weight: .bold))
+        Image(systemName: "person.circle.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func plus(_ size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.plus.bold.frame(width: size, height: size)
+        Ph.plusCircle.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "plus").font(.system(size: size, weight: .bold))
+        Image(systemName: "plus.circle.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func microphone(_ size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.microphone.bold.frame(width: size, height: size)
+        Ph.microphone.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "mic").font(.system(size: size, weight: .bold))
+        Image(systemName: "mic.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func waveform(_ size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.waveform.bold.frame(width: size, height: size)
+        Ph.waveform.fill.frame(width: size, height: size)
         #else
         Image(systemName: "waveform").font(.system(size: size, weight: .bold))
         #endif
@@ -144,44 +144,44 @@ enum AppIcon {
     @ViewBuilder static func paperPlane(_ size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
         // Phosphor name: paper-plane-tilt
-        Ph.paperPlaneTilt.bold.frame(width: size, height: size)
+        Ph.paperPlaneTilt.fill.frame(width: size, height: size)
         #else
         Image(systemName: "paperplane.fill").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func chevronDown(_ size: CGFloat = 12) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.caretDown.bold.frame(width: size, height: size)
+        Ph.caretDown.fill.frame(width: size, height: size)
         #else
         Image(systemName: "chevron.down").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func chevronUp(_ size: CGFloat = 12) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.caretUp.bold.frame(width: size, height: size)
+        Ph.caretUp.fill.frame(width: size, height: size)
         #else
         Image(systemName: "chevron.up").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func copy(_ size: CGFloat = 14) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.copy.bold.frame(width: size, height: size)
+        Ph.copy.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "doc.on.doc").font(.system(size: size, weight: .bold))
+        Image(systemName: "doc.on.doc.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func info(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.info.bold.frame(width: size, height: size)
+        Ph.info.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "info.circle").font(.system(size: size, weight: .bold))
+        Image(systemName: "info.circle.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func close(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.x.bold.frame(width: size, height: size)
+        Ph.x.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "xmark").font(.system(size: size, weight: .bold))
+        Image(systemName: "xmark.circle.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func stop(_ size: CGFloat = 18) -> some View {
@@ -190,7 +190,7 @@ enum AppIcon {
     }
     @ViewBuilder static func checkCircle(_ filled: Bool = true, size: CGFloat = 18) -> some View {
         #if canImport(PhosphorSwift)
-        (filled ? Ph.checkCircle : Ph.circle).bold.frame(width: size, height: size)
+        (filled ? Ph.checkCircle.fill : Ph.circle.bold).frame(width: size, height: size)
         #else
         Image(systemName: filled ? "checkmark.circle.fill" : "circle").font(.system(size: size, weight: .bold))
         #endif
@@ -198,7 +198,7 @@ enum AppIcon {
     @ViewBuilder static func starsHeader(_ size: CGFloat = 14) -> some View {
         #if canImport(PhosphorSwift)
         // Use "moon-stars" for assistant header flair
-        Ph.moonStars.bold.frame(width: size, height: size)
+        Ph.moonStars.fill.frame(width: size, height: size)
         #else
         Image(systemName: "sparkles").font(.system(size: size, weight: .bold))
         #endif
@@ -207,28 +207,28 @@ enum AppIcon {
     // Provider icons
     @ViewBuilder static func providerOpenAI(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.lightning.bold.frame(width: size, height: size)
+        Ph.lightning.fill.frame(width: size, height: size)
         #else
         Image(systemName: "bolt.horizontal.circle.fill").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func providerAnthropic(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.circleNotch.bold.frame(width: size, height: size)
+        Ph.circleNotch.fill.frame(width: size, height: size)
         #else
         Image(systemName: "a.circle.fill").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func providerGoogle(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.googleLogo.bold.frame(width: size, height: size)
+        Ph.googleLogo.fill.frame(width: size, height: size)
         #else
         Image(systemName: "g.circle.fill").font(.system(size: size, weight: .bold))
         #endif
     }
     @ViewBuilder static func providerXAI(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.x.bold.frame(width: size, height: size)
+        Ph.x.fill.frame(width: size, height: size)
         #else
         Image(systemName: "x.circle.fill").font(.system(size: size, weight: .bold))
         #endif
@@ -237,23 +237,23 @@ enum AppIcon {
     // Action icons
     @ViewBuilder static func refresh(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.arrowClockwise.bold.frame(width: size, height: size)
+        Ph.arrowClockwise.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "arrow.clockwise.circle").font(.system(size: size, weight: .bold))
+        Image(systemName: "arrow.clockwise.circle.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func refreshModels(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.arrowsClockwise.bold.frame(width: size, height: size)
+        Ph.arrowsClockwise.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "arrow.triangle.2.circlepath").font(.system(size: size, weight: .bold))
+        Image(systemName: "arrow.triangle.2.circlepath").font(.system(size: size, weight: .heavy))
         #endif
     }
     @ViewBuilder static func lightning(_ size: CGFloat = 16) -> some View {
         #if canImport(PhosphorSwift)
-        Ph.lightning.bold.frame(width: size, height: size)
+        Ph.lightning.fill.frame(width: size, height: size)
         #else
-        Image(systemName: "bolt.horizontal.circle").font(.system(size: size, weight: .bold))
+        Image(systemName: "bolt.horizontal.circle.fill").font(.system(size: size, weight: .heavy))
         #endif
     }
 }

--- a/MyChat/SettingsView.swift
+++ b/MyChat/SettingsView.swift
@@ -68,19 +68,21 @@ struct SettingsView: View {
                 }
                 Section("Defaults") {
                     Picker("Default Provider", selection: $store.defaultProvider) {
-                        Text("OpenAI").tag("openai")
-                        Text("Anthropic").tag("anthropic")
-                        Text("Google").tag("google")
-                        Text("XAI").tag("xai")
+                        Text("OpenAI").fontWeight(.semibold).tag("openai")
+                        Text("Anthropic").fontWeight(.semibold).tag("anthropic")
+                        Text("Google").fontWeight(.semibold).tag("google")
+                        Text("XAI").fontWeight(.semibold).tag("xai")
                     }
+                    .fontWeight(.semibold)
                     .onChange(of: store.defaultProvider) { _, _ in store.save() }
 
                     // Model picker based on enabled models for the selected provider
                     Picker("Default Model", selection: $store.defaultModel) {
                         ForEach(modelsForSelectedProvider(), id: \.self) { m in
-                            Text(m).tag(m)
+                            Text(m).fontWeight(.semibold).tag(m)
                         }
                     }
+                    .fontWeight(.semibold)
                     .pickerStyle(.menu)
                     .disabled(modelsForSelectedProvider().isEmpty)
                     .onChange(of: store.defaultModel) { _, _ in store.save() }


### PR DESCRIPTION
## Summary
- switch app icons to filled/heavy variants for stronger presence
- apply semibold weight to colored picker text for better legibility

## Testing
- `xcodebuild -project MyChat.xcodeproj -scheme MyChat -destination 'generic/platform=iOS Simulator' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c36d048b94832ebd816cba7c804edc